### PR TITLE
Update to support 1.19.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.11-SNAPSHOT'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,13 @@
 plugins {
-	id 'fabric-loom' version '0.10.13'
+	id 'fabric-loom' version '0.11-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = 16
-targetCompatibility = 16
+sourceCompatibility = 17
+targetCompatibility = 17
 
 archivesBaseName = "${modid}"
 version = "${version}" + "-" + project.minecraft_version
-
-minecraft {
-}
 
 repositories {
 	maven { url = "https://maven.fabricmc.net/" }
@@ -39,8 +36,8 @@ tasks.withType(JavaCompile).configureEach {
 	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
 
-	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
+	// Minecraft 1.18 upwards uses Java 17.
+	it.options.release = 17
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@
 org.gradle.jvmargs=-Xmx1G
 
 ## Minecraft & Fabric Dependency Versions
-minecraft_version = 1.18.2
+minecraft_version = 1.19
 # https://maven.fabricmc.net/net/fabricmc/yarn
-yarn_mappings = 1.18.2+build.2
+yarn_mappings = 1.19+build.2
 # https://maven.fabricmc.net/net/fabricmc/fabric-loader
-loader_version = 0.13.3
+loader_version = 0.14.7
 
 ## Mod Information
 version=1.3.1
 modid=betterdroppeditems
 
-fabric_version=0.48.0+1.18.2
+fabric_version=0.55.3+1.19

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@
 org.gradle.jvmargs=-Xmx1G
 
 ## Minecraft & Fabric Dependency Versions
-minecraft_version = 21w37a
+minecraft_version = 1.18.2
 # https://maven.fabricmc.net/net/fabricmc/yarn
-yarn_mappings = 21w37a+build.8
+yarn_mappings = 1.18.2+build.2
 # https://maven.fabricmc.net/net/fabricmc/fabric-loader
-loader_version = 0.11.7
+loader_version = 0.13.3
 
 ## Mod Information
 version=1.3.1
 modid=betterdroppeditems
 
-fabric_version=0.40.3+1.18
+fabric_version=0.48.0+1.18.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/bdi/mixin/ItemEntityRendererMixin.java
+++ b/src/main/java/bdi/mixin/ItemEntityRendererMixin.java
@@ -55,7 +55,7 @@ public abstract class ItemEntityRendererMixin extends EntityRenderer<ItemEntity>
         this.random.setSeed(seed);
 
         matrix.push();
-        BakedModel bakedModel = this.itemRenderer.getHeldItemModel(itemStack, dropped.world, null, seed);
+        BakedModel bakedModel = this.itemRenderer.getModel(itemStack, dropped.world, null, seed);
         boolean hasDepthInGui = bakedModel.hasDepth();
 
         // decide how many item layers to render

--- a/src/main/java/bdi/mixin/ItemEntityRendererMixin.java
+++ b/src/main/java/bdi/mixin/ItemEntityRendererMixin.java
@@ -28,12 +28,12 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Random;
+import net.minecraft.util.math.random.Random;
 
 @Mixin(ItemEntityRenderer.class)
 public abstract class ItemEntityRendererMixin extends EntityRenderer<ItemEntity> {
 
-    @Shadow @Final private Random random;
+    @Shadow @Final private Random random = Random.create();
     @Shadow @Final private ItemRenderer itemRenderer;
     @Shadow protected abstract int getRenderedAmount(ItemStack stack);
 

--- a/src/main/resources/betterdroppeditems.mixins.json
+++ b/src/main/resources/betterdroppeditems.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "bdi.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "ItemEntityMixin",
     "ItemEntityRendererMixin"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,8 +22,8 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.11.3",
-    "minecraft": "1.18.x",
+    "fabricloader": ">=0.13.3",
+    "minecraft": "1.18.2",
     "fabric": "*"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,8 +22,8 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.13.3",
-    "minecraft": "1.18.2",
+    "fabricloader": ">=0.14.7",
+    "minecraft": "1.19",
     "fabric": "*"
   }
 }


### PR DESCRIPTION
[1] Update mapping to 1.19
[2] Adapt to Java 17
[3] Drop jcenter as it's depricated